### PR TITLE
fix/58 reservation 조회 오류 수정 (인 줄 알았으나 아무 문제 없던 것으로 확인)

### DIFF
--- a/src/main/java/site/strangebros/nork/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/site/strangebros/nork/domain/reservation/controller/ReservationController.java
@@ -39,14 +39,17 @@ public class ReservationController {
 
         // 유저의 모든 예약 조회(모든 워크스페이스에 대하여) - 마이페이지 -> 전체 예약 보기
         if(readRequest.getAll()){
+            //System.out.println("유저의 모든 예약 조회 시작. all: "+readRequest.getAll()+", workspaceId: "+readRequest.getWorkspaceId());
             reservations = reservationService.readAllReservation(readRequest, memberId);
         }
         // 유저의 상위 3개 예약 조회(단일 워크스페이스에 대하여, 현재보다 이후 날짜) - 워크스페이스 화면
         else if(readRequest.getWorkspaceId() != -1){
+            //System.out.println("유저의 단일 워크스페이스에 대하여 상위 3개 예약 조회 시작. all: "+readRequest.getAll()+", workspaceId: "+readRequest.getWorkspaceId());
             reservations = reservationService.readWorkspaceReservation(readRequest, memberId);
         }
         // 유저의 상위 3개 예약 조회(모든 워크스페이스에 대하여, 현재보다 이후 날짜) - 마이페이지 메인 화면
         else{
+            //System.out.println("유저의 모든 워크스페이스에 대하여 상위 3개 예약 조회 시작. all: "+readRequest.getAll()+", workspaceId: "+readRequest.getWorkspaceId());
             reservations = reservationService.readReservation(readRequest, memberId);
         }
 


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #58 

### 📝 작업 내용
- 사실 너무 잘 되던 거였음...
- 유저의 특정 워크스페이스에 대한 예약와, 유저의 예약 3개 조회 기능은 현재보다 이전 날짜의 예약은 조회하지 않았음.
- 모든 예약 조회는 날짜에 상관없이 보여주기 때문에 보이는 거였음. 
- 실행 화면
    - pathvariable에 따라서 각각 다른 메서드가 실행되는 것을 테스트 해 보았음. 잘 된다.
    - ![image](https://github.com/strangebros/nork-backend/assets/83462874/7544a0cf-23f9-4578-8220-5262bbead502)
    - db에 가서 특정 예약의 날짜를 현재보다 이후 날짜로 변경하였음.
    - ![image](https://github.com/strangebros/nork-backend/assets/83462874/b4f532df-623d-481a-9fd4-86beff6f3aa3)
    - 유저의 가장 빠른 예약 3개 조회 (pathvariable에 아무것도 안넣음)
    - ![image](https://github.com/strangebros/nork-backend/assets/83462874/6212bd96-1cdd-4852-9542-df8d39f82cf2)
    - 유저의 특정 워크스페이스에 대한 모든 예약 조회
    - ![image](https://github.com/strangebros/nork-backend/assets/83462874/d370bb17-ce10-4fd4-a6ae-1799a08184ed)

### 🙏 리뷰 요구사항
- ![image](https://github.com/strangebros/nork-backend/assets/83462874/742b5b19-1b3b-4968-9414-4647a6f648fd)
- 정신 차리고 테스트 하겠습니다...

