### PR TITLE
fix: 유저의 모든 리뷰를 불러오는 쿼리에서 중첩되는 쿼리 수정

### DIFF
--- a/src/main/resources/mapper/review.xml
+++ b/src/main/resources/mapper/review.xml
@@ -17,7 +17,7 @@
 
     <!-- 유저의 특정 장소에 대한 모든 리뷰 불러오기 -->
     <select id="findByMemberIdAndWorkspaceId" parameterType="map" resultMap="reviewResultMap">
-        select vr.review_id as review_id,
+        select vr.id as review_id,
                vr.member_id,
                vr.workspace_id,
                w.name as workspace_name,
@@ -30,22 +30,14 @@
                vri.image,
                rk.id        as review_keyword_id,
                rk.keyword_id
-        from (select vr.id as review_id,
-                     vr.member_id,
-                     vr.workspace_id,
-                     vr.start_datetime,
-                     vr.end_datetime,
-                     vr.activity,
-                     vr.rating,
-                     vr.review_text
-              from visited_review vr
-              where vr.member_id = #{readInfo.memberId}
-              and vr.workspace_id = #{readInfo.workspaceId}
-              order by vr.start_datetime desc
-                  limit #{count} offset #{offset}) as vr
-                left join workspace w on vr.workspace_id = w.id
-                 left join visited_review_image vri on vr.review_id = vri.visited_review_id
-                 left join review_keyword rk on vr.review_id = rk.visited_review_id
+        from visited_review vr
+                 left join workspace w on vr.workspace_id = w.id
+                 left join visited_review_image vri on vr.id = vri.visited_review_id
+                 left join review_keyword rk on vr.id = rk.visited_review_id
+        where vr.member_id = #{readInfo.memberId}
+          and vr.workspace_id = #{readInfo.workspaceId}
+        order by vr.start_datetime desc
+            limit #{count} offset #{offset};
     </select>
 
     <!-- 유저의 모든 리뷰 불러오기 (모든 장소에 대한) -->
@@ -70,7 +62,6 @@
         where vr.member_id = #{readInfo.memberId}
         order by vr.start_datetime desc
             limit #{count} offset #{offset};
-
     </select>
 
     <!-- 단일 리뷰 조회(업데이트 시 정보를 불러오기 위함) -->

--- a/src/main/resources/mapper/review.xml
+++ b/src/main/resources/mapper/review.xml
@@ -50,7 +50,7 @@
 
     <!-- 유저의 모든 리뷰 불러오기 (모든 장소에 대한) -->
     <select id="findByMemberId" parameterType="map" resultMap="reviewResultMap">
-        select vr.review_id as review_id,
+        select vr.id as review_id,
                vr.member_id,
                vr.workspace_id,
                w.name as workspace_name,
@@ -63,21 +63,14 @@
                vri.image,
                rk.id        as review_keyword_id,
                rk.keyword_id
-        from (select vr.id as review_id,
-                     vr.member_id,
-                     vr.workspace_id,
-                     vr.start_datetime,
-                     vr.end_datetime,
-                     vr.activity,
-                     vr.rating,
-                     vr.review_text
-                  from visited_review vr
-                  where vr.member_id = #{readInfo.memberId}
-                  order by vr.start_datetime desc
-                  limit #{count} offset #{offset}) as vr
+        from visited_review vr
+                 left join visited_review_image vri on vr.id = vri.visited_review_id
+                 left join review_keyword rk on vr.id = rk.visited_review_id
                  left join workspace w on vr.workspace_id = w.id
-                 left join visited_review_image vri on vr.review_id = vri.visited_review_id
-                 left join review_keyword rk on vr.review_id = rk.visited_review_id
+        where vr.member_id = #{readInfo.memberId}
+        order by vr.start_datetime desc
+            limit #{count} offset #{offset};
+
     </select>
 
     <!-- 단일 리뷰 조회(업데이트 시 정보를 불러오기 위함) -->


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #77 

### 📝 작업 내용
**개선 이전**
- 용량이 큰 이미지 파일이 등록되어 있는 리뷰들 조회 시: 평균 **2.5초**
- ![image](https://github.com/user-attachments/assets/7e081441-5939-470c-9a7c-be0a9e120131)
- 첫 조회 시 10초 이상 소요. 이후 조회 시 2초~3초가량 소요.

**개선 내용**
- 기존의 중첩 쿼리를 제거하고, 직접 `JOIN`을 사용하여 데이터베이스가 더 효과적으로 조인 순서를 최적화하도록 개선함. 
- 서브쿼리로 인해 중간 데이터를 처리하는 비효율을 제거하고, 단일 조인으로 최적의 실행 계획을 수립할 수 있게 함.

**개선 이후**
- 용량이 큰 이미지 파일이 등록되어 있는 리뷰들 조회 시: 평균 **0.45초**
- ![image](https://github.com/user-attachments/assets/b44c4759-05c2-489c-95ff-a5deb66f37d1)
- 첫 조회시 1.5초가량 소요되며, 이후 평균 응답 시간은 0.45초로 크게 개선됨.

**테스트 환경**
- 테스트는 Postman을 이용하여 실제 API 호출 환경에서 수행하였음. 
- 동일한 서버 자원과 네트워크 상태에서 반복적으로 테스트하여 결과를 도출하였음.

**기대 효과**
- 해당 API가 마이페이지를 들어갈 때 사용되는 API이고, 해당 API의 호출이 완료되어야 마이페이지 화면이 나오는 구조였기 때문에, 마이페이지 로딩 시간이 API 호출 시간에 영향을 받았음.
- 조회 시간이 단축된 만큼, 마이페이지에서의 유저 사용성 개선 효과 기대

### 🙏 이후 개발 계획
**S3를 사용하여 이미지 저장**
- 현재 base64방식을 활용하여 이미지를 저장 중인데, 유저의 모든 리뷰를 조회해야 하는 경우 큰 이미지들이 여러 장 있기 때문에 속도 저하가 일어날 가능성이 있다고 생각함.
- 따라서, AWS S3를 활용하여 사진 이미지를 저장하고, DB에는 S3 url만 저장하도록 리팩토링 한다면, 조회 시간을 크게 단축할 수 있다고 생각함.